### PR TITLE
Fix wms link within es online resources

### DIFF
--- a/georeference/scripts/es.py
+++ b/georeference/scripts/es.py
@@ -76,7 +76,7 @@ def _getOnlineResourceWMS(originalMapObj):
     """
     # append WMS
     return {
-        'url': '%(link_service)s?SERVICE=WMS&VERSION=2.0.0&REQUEST=GetCapabilities' % ({
+        'url': '%(link_service)s?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetCapabilities' % ({
             'link_service': TEMPLATE_PUBLIC_WMS_URL % originalMapObj.id,
         }),
         'type': 'WMS'


### PR DESCRIPTION
This pull-request fixes a bug within the generation of the GetCapabilities links für the WMS. The previous version of `2.0.0` was a copy & paste error, because this version is not support throught the WMS. Because of this the version is ignored by the Service and `1.3.0` is used instead.