### PR TITLE
Upgrades and fixes for proper support of the upload-client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ scripts/uploads
 scripts/*.json
 scripts/*.tif
 scripts/*.tar.gz
+scripts/kartenforum_georeference
 
 # do not track sql dumps and log files
 *.dump

--- a/README.md
+++ b/README.md
@@ -69,4 +69,20 @@ docker-compose up
 
 * If the execution of the command `./python_env/bin/python setup.py develop` fails with "Unknown distribution option: 'use_2to3_fixers'", install an older version of the setup tools in your virtualenv (<58).
 
+## Test requests
 
+Following some curl commands for testing the maps endpoint:
+
+``` 
+# Creates a new map
+curl 'http://localhost:6543/maps/?user_id=test_user' \
+  -s \
+  -F 'file=@/home/someuser/test.tif' \
+  -F 'metadata={"allow_download":false,"description":"Test","license":"CC-BY-SA 4.0","map_type":"ak","map_scale":25000,"time_of_publication":"1846-01-01T00:00:00","title":"Der volle Titel der PIKOMAP","title_short":"PIKOMAP"}
+  
+# Updates a map 
+curl 'http://localhost:6543/maps/{map_id}?user_id=test_user' \
+  -s \
+  -F 'file=@/home/someuser/test.tif' \
+  -F 'metadata={"allow_download":false,"description":"Noch ein test","license":"CC-BY-SA 4.0","map_type":"ak","map_scale":25000,"time_of_publication":"1846-01-01T00:00:00","title":"Der volle Titel der PIKOMAP","title_short":"PIKOMAP"}'
+```

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -7,7 +7,6 @@ services:
   db:
     container_name: pg_container
     image: postgis/postgis:13-master
-    restart: always
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
@@ -18,7 +17,6 @@ services:
   mapserver:
     container_name: mapserver
     image: camptocamp/mapserver
-    restart: unless-stopped
     volumes:
       - ../tmp/tmp/:/etc/mapserver/
       - ../tmp/tmp/:/mapdata/

--- a/georeference/__init__.py
+++ b/georeference/__init__.py
@@ -80,7 +80,7 @@ def createApplication(debug_mode=False, **settings):
     config.scan('views', onerror=onError)
 
     # Enable cors
-    config.include('.cors')
+    # config.include('.cors')
 
     # Make json renderer output datetimes
     json_renderer = config.registry.getUtility(IRendererFactory, name="json")

--- a/georeference/jobs/process_update_maps.py
+++ b/georeference/jobs/process_update_maps.py
@@ -196,11 +196,11 @@ def _reset_georef_state_for_map(map_id, dbsession):
         georef_path = georef_map_object.get_abs_path()
         remove_if_exists(georef_path)
 
-    # remove georef map from db
-    dbsession.delete(georef_map_object)
+        # remove georef map from db
+        dbsession.delete(georef_map_object)
 
-    # Delete all related transformations
-    dbsession.query(Transformation).filter(Transformation.raw_map_id == map_id).delete()
+        # Delete all related transformations
+        dbsession.query(Transformation).filter(Transformation.raw_map_id == map_id).delete()
 
 
 def _should_generate_files(metadata, metadata_updates, key, base_url, is_file_updated):

--- a/georeference/views/maps.py
+++ b/georeference/views/maps.py
@@ -67,6 +67,8 @@ def GET_map_for_map_id(request):
         response_obj["map_id"] = to_public_map_id(map_obj.id)
         response_obj["transformation_id"] = None
         response_obj["map_type"] = map_obj.map_type
+        response_obj["allow_download"] = map_obj.allow_download
+        response_obj["map_scale"] = map_obj.map_scale if map_obj.map_scale is not None else 25000
 
         # In case there is currently an active georeference process for the map return the id
         georef_map_obj = GeorefMap.by_raw_map_id(map_obj.id, request.dbsession)

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Set the directory name and files to copy
+directory_name="kartenforum_georeference"
+
+# Create the directory
+rm -r "$directory_name"
+mkdir "$directory_name"
+
+# Copy files
+cp -r ../georeference "$directory_name"/georeference
+rm -r "$directory_name"/georeference/__test_data
+cp ../production.ini "$directory_name"/
+cp ../setup.py "$directory_name"/
+
+# Remove all __pycache__ directory
+find "./$directory" -type d -name "__pycache__" -exec rm -rf {} \;
+
+# Package directory
+tar -czf georeference.tar.gz "$directory_name/"


### PR DESCRIPTION
This PR includes a series of improvements regarding the georeference service. 

### Changes
* CORS should be handled through the reverse proxy and not the service.
* Fix some smaller issues within the Uploads-API endpoint
* Add a script for packaging the API 
* Remove `restart: always` from docker scripts