### PR TITLE
Develop fix tms creation

### DIFF
--- a/georeference/jobs/actions/create_geo_image.py
+++ b/georeference/jobs/actions/create_geo_image.py
@@ -13,6 +13,7 @@ from georeference.utils.georeference import rectify_image_with_clip_and_overview
 from georeference.utils.parser import to_gdal_gcps
 from georeference.utils.proj import transform_to_params_to_target_crs
 
+
 def run_process_geo_image(transformation_obj, path_raw_image, path_geo_image, logger, force=False, clip=None):
     """ This actions generates a persistent geo image for a given transformation object and a raw image.
 
@@ -32,11 +33,13 @@ def run_process_geo_image(transformation_obj, path_raw_image, path_geo_image, lo
     :rtype: str
     """
     if not os.path.exists(path_raw_image):
-        logger.debug('Skip processing of geo image for map "%s", because of missing raw image.' % transformation_obj.raw_map_id)
+        logger.debug(
+            'Skip processing of geo image for map "%s", because of missing raw image.' % transformation_obj.raw_map_id)
         return None
 
     if os.path.exists(path_geo_image) and force == False:
-        logger.debug('Skip processing of geo image for map "%s", because of an already existing geo image. Use "force" parameter in case you want to overwrite it.' % transformation_obj.raw_map_id)
+        logger.debug(
+            'Skip processing of geo image for map "%s", because of an already existing geo image. Use "force" parameter in case you want to overwrite it.' % transformation_obj.raw_map_id)
         return path_geo_image
 
     # Parse georef parameters. Since newer version it is possible that the target crs of the gcps are different from
@@ -45,9 +48,9 @@ def run_process_geo_image(transformation_obj, path_raw_image, path_geo_image, lo
     georef_params = transformation_obj.get_params_as_dict()
     georef_params = transform_to_params_to_target_crs(
         transformation_obj.get_params_as_dict(),
-        transformation_obj.get_target_crs_as_string() if transformation_obj.target_crs is not None else georef_params['target']
+        transformation_obj.get_target_crs_as_string() if transformation_obj.target_crs is not None else georef_params[
+            'target']
     )
-
 
     # Try processing a geo transformation
     rectify_image_with_clip_and_overviews(

--- a/georeference/jobs/actions/create_geo_services_test.py
+++ b/georeference/jobs/actions/create_geo_services_test.py
@@ -14,17 +14,18 @@ from .create_geo_services import run_process_geo_services
 # Initialize the logger
 LOGGER = logging.getLogger(__name__)
 
-def test_run_process_geo_services_success():
+
+def test_runProcessGeoServices_success():
     """ The proper working of the action for processing geo services for a geo images. """
     try:
         # Perform the test
-        test_data = create_test_data('test_runProcessGeoServices_success')
-        test_mapfile = os.path.join(os.path.dirname(os.path.realpath(__file__)),
-                           '../../data_output/%s.map' % 'test_runProcessGeoServices_success')
-        path_geo_image = run_process_geo_image(
-            test_data['transformationObj'],
-            test_data['srcPath'],
-            test_data['trgPath'],
+        testData = create_test_data('test_runProcessGeoServices_success')
+        testMapfile = os.path.join(os.path.dirname(os.path.realpath(__file__)),
+                                   '../../georeference_tests/data_output/%s.map' % 'test_runProcessGeoServices_success')
+        pathGeoImage = run_process_geo_image(
+            testData['transformationObj'],
+            testData['srcPath'],
+            testData['trgPath'],
             logger=LOGGER
         )
 
@@ -35,13 +36,14 @@ def test_run_process_geo_services_success():
             "test_runProcessGeoServices_success",
             "Test",
             LOGGER,
-            with_wcs = True
+            with_wcs=True
         )
 
         assert subject is not None
         assert os.path.exists(subject)
     finally:
-        if path_geo_image is not None and os.path.exists(path_geo_image):
-            os.remove(path_geo_image)
-        if subject is not None and os.path.exists(subject):
+
+        if os.path.exists(pathGeoImage):
+            os.remove(pathGeoImage)
+        if os.path.exists(subject):
             os.remove(subject)

--- a/georeference/jobs/actions/create_tms.py
+++ b/georeference/jobs/actions/create_tms.py
@@ -10,7 +10,8 @@ import shutil
 from georeference.settings import GLOBAL_TMS_PROCESSES
 from georeference.utils.tms import calculate_compressed_tms
 
-def run_process_tms(path_tms_dir, path_geo_image, logger, map_scale, force = False):
+
+def run_process_tms(path_tms_dir, path_geo_image, logger, force=False):
     """ This actions generate a Tile Map Service (TMS) for a given geo services. It therefore heavily relies on the
         gdal utility tool, gdal2tiles. See also https://gdal.org/programs/gdal2tiles.html
 
@@ -20,8 +21,6 @@ def run_process_tms(path_tms_dir, path_geo_image, logger, map_scale, force = Fal
     :type path_geo_image: str
     :param logger: Logger
     :type logger: logging.Logger
-    :param map_scale: Scale of the map. Is necessary for guessing the correct number of zoom levels supported by the tms.
-    :type map_scale: int
     :param force: Signals if the function should overwrite an already existing tms cache (Default: False)
     :type force: bool
     :result: Path of the tms cache directory
@@ -32,7 +31,8 @@ def run_process_tms(path_tms_dir, path_geo_image, logger, map_scale, force = Fal
         return None
 
     if os.path.exists(path_tms_dir) and force == False:
-        logger.debug('Skip processing of tms for geo image "%s", because of an already existing tms. Use "force" parameter in case you want to overwrite it.' % path_tms_dir)
+        logger.debug(
+            'Skip processing of tms for geo image "%s", because of an already existing tms. Use "force" parameter in case you want to overwrite it.' % path_tms_dir)
         return path_tms_dir
 
     # In case a tms directory exist clean it
@@ -45,7 +45,6 @@ def run_process_tms(path_tms_dir, path_geo_image, logger, map_scale, force = Fal
         path_tms_dir,
         logger,
         GLOBAL_TMS_PROCESSES,
-        map_scale
     )
 
     return path_tms_dir

--- a/georeference/jobs/actions/create_tms_test.py
+++ b/georeference/jobs/actions/create_tms_test.py
@@ -15,13 +15,14 @@ from .create_tms import run_process_tms
 # Initialize the logger
 LOGGER = logging.getLogger(__name__)
 
+
 def test_runProcessTMS_success():
     """ The proper working of the action for processing tms directories. """
     try:
         # Perform the test
         testData = create_test_data('test_runProcessTMS_success')
         testTmsDir = os.path.join(os.path.dirname(os.path.realpath(__file__)),
-                           '../../data_output/test_tms_%s.tif' % 'test_runProcessTMS_success')
+                                  '../../georeference_tests/data_output/test_tms_%s.tif' % 'test_runProcessTMS_success')
         pathGeoImage = run_process_geo_image(
             testData['transformationObj'],
             testData['srcPath'],
@@ -33,7 +34,6 @@ def test_runProcessTMS_success():
             testTmsDir,
             pathGeoImage,
             logger=LOGGER,
-            map_scale=10000000,
         )
 
         assert True == os.path.exists(pathGeoImage)
@@ -43,13 +43,14 @@ def test_runProcessTMS_success():
         if os.path.exists(tmsDir):
             shutil.rmtree(tmsDir)
 
+
 def test_runProcessTMS_force_success():
     """ The proper working of the action for processing tms directories. """
     try:
         # Initial create the process
         testData = create_test_data('test_runProcessTMS_force_success')
         testTmsDir = os.path.join(os.path.dirname(os.path.realpath(__file__)),
-                           '../../data_output/test_tms_%s.tif' % 'test_runProcessTMS_force_success')
+                                  '../../georeference_tests/data_output/test_tms_%s.tif' % 'test_runProcessTMS_force_success')
         pathGeoImage = run_process_geo_image(
             testData['transformationObj'],
             testData['srcPath'],
@@ -61,7 +62,6 @@ def test_runProcessTMS_force_success():
             testTmsDir,
             pathGeoImage,
             logger=LOGGER,
-            map_scale=10000000,
         )
         firstModificationTime = os.path.getmtime(subject)
 
@@ -71,7 +71,6 @@ def test_runProcessTMS_force_success():
             testTmsDir,
             pathGeoImage,
             logger=LOGGER,
-            map_scale=10000000,
         )
         secondModificationTime = os.path.getmtime(subject)
 
@@ -81,7 +80,6 @@ def test_runProcessTMS_force_success():
             testTmsDir,
             pathGeoImage,
             logger=LOGGER,
-            map_scale=10000000,
             force=True
         )
         thirdModificationTime = os.path.getmtime(subject)

--- a/georeference/jobs/actions/enable_transformation.py
+++ b/georeference/jobs/actions/enable_transformation.py
@@ -40,7 +40,7 @@ def run_enable_transformation(transformation_obj, es_index, dbsession, logger):
     metadataObj = Metadata.by_map_id(rawMapObj.id, dbsession)
 
     # In case a georefMapObj does not exist, create a new one
-    if georefMapObj == None:
+    if georefMapObj is None:
         logger.debug('Create new georef map object for original map id %s.' % rawMapObj.id)
         georefMapObj = GeorefMap.from_raw_map_and_transformation(rawMapObj, transformation_obj)
         dbsession.add(georefMapObj)
@@ -67,7 +67,6 @@ def run_enable_transformation(transformation_obj, es_index, dbsession, logger):
         get_tms_directory(rawMapObj),
         pathGeoImage,
         logger=logger,
-        map_scale=rawMapObj.map_scale,
         force=True
     )
 

--- a/georeference/jobs/initialize_data.py
+++ b/georeference/jobs/initialize_data.py
@@ -24,17 +24,13 @@ from georeference.models.transformations import Transformation
 from georeference.settings import PATH_MOSAIC_ROOT, ES_ROOT, ES_INDEX_NAME
 
 
-def run_initialize_data(dbsession, logger, overwrite_map_scale=False):
+def run_initialize_data(dbsession, logger):
     """ This job checks the database and initially builds the index and missing georeference images.
 
     :param dbsession: Database session object
     :type dbsession: sqlalchemy.orm.session.Session
     :param logger: Logger
     :type logger: logging.Logger
-    :param overwrite_map_scale: Allows a default setting of the map_scale used for tms cache generation. In production
-        this parameter should be skipped. In testing this parameter can be used for allow faster test excution, because
-        the tms generation is a long running process. (Default: False)
-    :type overwrite_map_scale: bool
     :result: True if performed successfully
     :rtype: bool
     """
@@ -51,7 +47,7 @@ def run_initialize_data(dbsession, logger, overwrite_map_scale=False):
 
             # If a georef map is registered within the database, make sure that also a geo image, a tms cache and
             # geo service (mapfile) does exist.
-            if georef_map_obj != None and os.path.exists(raw_map_obj.get_abs_path()):
+            if georef_map_obj is not None and os.path.exists(raw_map_obj.get_abs_path()):
                 transformation_obj = Transformation.by_id(georef_map_obj.transformation_id, dbsession)
 
                 # Make sure to process the geo image. We do not use the "force" parameter, which skips this
@@ -75,7 +71,6 @@ def run_initialize_data(dbsession, logger, overwrite_map_scale=False):
                     get_tms_directory(raw_map_obj),
                     path_geo_image,
                     logger=logger,
-                    map_scale=10000000 if overwrite_map_scale == True else raw_map_obj.map_scale,
                 )
 
                 # Process the map file

--- a/georeference/jobs/process_update_maps.py
+++ b/georeference/jobs/process_update_maps.py
@@ -52,6 +52,7 @@ def run_process_update_maps(es_index, dbsession, logger, job):
     processed_image_path = raw_map_object.get_abs_path()
 
     is_file_updated = 'file' in description and description['file'] is not None
+    logger.debug(f'Update file: {is_file_updated}')
 
     if is_file_updated:
         if not os.path.exists(PATH_IMAGE_ROOT):
@@ -91,11 +92,14 @@ def run_process_update_maps(es_index, dbsession, logger, job):
     dbsession.flush()
 
     # delete transformations and georef map
+    georef_obj = None
     if is_file_updated:
         _reset_georef_state_for_map(map_id, dbsession)
+    else:
+        georef_obj = GeorefMap.by_raw_map_id(map_id, dbsession)
 
     # update index
-    run_update_index(es_index, raw_map_object, None, dbsession, logger)
+    run_update_index(es_index, raw_map_object, georef_obj, dbsession, logger)
 
 
 def generate_thumbnail(base_image_path, map_id, size, logger):

--- a/georeference/templates/wms_dynamic.map
+++ b/georeference/templates/wms_dynamic.map
@@ -12,8 +12,8 @@ MAP
         "wms_enable_request" "*"
         "wms_titel" "Temporary Web Map Service for georeference new images."
         "wms_contactorganization" "Saxon State and University Library Dresden (SLUB)"
-        "wms_contactperson" "Alexander Bigga"
-        "wms_contactelectronicmailaddress" "alexander.bigga@slub-dresden.de"
+        "wms_contactperson" "Dominik Stoltz"
+        "wms_contactelectronicmailaddress" "dominik.stoltz@slub-dresden.de"
         "wms_abstract" "$wmsAbstract"
     END
   END

--- a/georeference/templates/wms_mosaic_static.map
+++ b/georeference/templates/wms_mosaic_static.map
@@ -35,8 +35,8 @@ MAP
       "wms_title" "WMS $layerTitle"
       "wms_accessconstraints" "Alle Metadaten stehen unter der CC0-Lizenz zur Verfuegung. Alle ueber die Infrastruktur des Virtuellen Kartenforum angeboten Karten mit einer Datierung vor 1900 stehen unter CC-BY-SA 4.0 zur Verfuegung. Für juengere Karten gilt aus urheberrechtlichen Gruenden Rechte vorbehalten/rights reserved. Naehere Informationen finden sie auch in den Nutzungsbestimmungen auf den Webseiten der SLUB (http://www.deutschefotothek.de)."
       "wms_contactorganization" "Saxon State and University Library Dresden (SLUB)"
-      "wms_contactperson" "Alexander Bigga"
-      "wms_contactelectronicmailaddress" "alexander.bigga@slub-dresden.de"
+      "wms_contactperson" "Dominik Stoltz"
+      "wms_contactelectronicmailaddress" "dominik.stoltz@slub-dresden.de"
       "wms_abstract" "WMS $layerTitle"
     END
   END

--- a/georeference/templates/wms_static.map
+++ b/georeference/templates/wms_static.map
@@ -43,8 +43,8 @@ MAP
       "wms_title" "Web Map Service for serving $layerName"
       "wms_accessconstraints" "Alle Metadaten stehen unter der CC0-Lizenz zur Verfuegung. Alle ueber die Infrastruktur des Virtuellen Kartenforum angeboten Karten mit einer Datierung vor 1900 stehen unter CC-BY-SA 4.0 zur Verfuegung. Für juengere Karten gilt aus urheberrechtlichen Gruenden Rechte vorbehalten/rights reserved. Naehere Informationen finden sie auch in den Nutzungsbestimmungen auf den Webseiten der SLUB (http://www.deutschefotothek.de)."
       "wms_contactorganization" "Saxon State and University Library Dresden (SLUB)"
-      "wms_contactperson" "Alexander Bigga"
-      "wms_contactelectronicmailaddress" "alexander.bigga@slub-dresden.de"
+      "wms_contactperson" "Dominik Stoltz"
+      "wms_contactelectronicmailaddress" "dominik.stoltz@slub-dresden.de"
       "wms_abstract" "Web Map Service for serving $layerName"
     END
   END

--- a/georeference/templates/wms_wcs_static.map
+++ b/georeference/templates/wms_wcs_static.map
@@ -43,8 +43,8 @@ MAP
       "wms_title" "Web Map Service for serving $layerName"
       "wms_accessconstraints" "Alle Metadaten stehen unter der CC0-Lizenz zur Verfuegung. Alle ueber die Infrastruktur des Virtuellen Kartenforum angeboten Karten mit einer Datierung vor 1900 stehen unter CC-BY-SA 4.0 zur Verfuegung. Für juengere Karten gilt aus urheberrechtlichen Gruenden Rechte vorbehalten/rights reserved. Naehere Informationen finden sie auch in den Nutzungsbestimmungen auf den Webseiten der SLUB (http://www.deutschefotothek.de)."
       "wms_contactorganization" "Saxon State and University Library Dresden (SLUB)"
-      "wms_contactperson" "Alexander Bigga"
-      "wms_contactelectronicmailaddress" "alexander.bigga@slub-dresden.de"
+      "wms_contactperson" "Dominik Stoltz"
+      "wms_contactelectronicmailaddress" "dominik.stoltz@slub-dresden.de"
       "wms_abstract" "Web Map Service for serving $layerName"
       "wcs_title" "Web Coverage Service for serving $layerName"
       "wcs_onlineresource" "$wcsUrl"
@@ -52,8 +52,8 @@ MAP
       "wcs_nativeformat" "GEOTIFF"
       "wcs_accessconstraints" "Alle Metadaten stehen unter der CC0-Lizenz zur Verfuegung. Alle ueber die Infrastruktur des Virtuellen Kartenforum angeboten Karten mit einer Datierung vor 1900 stehen unter CC-BY-SA 4.0 zur Verfuegung. Für juengere Karten gilt aus urheberrechtlichen Gruenden Rechte vorbehalten/rights reserved. Naehere Informationen finden sie auch in den Nutzungsbestimmungen auf den Webseiten der SLUB (http://www.deutschefotothek.de)."
       "wcs_enable_request" "*"
-      "wcs_contactperson" "Alexander Bigga"
-      "wcs_contactelectronicmailaddress" "alexander.bigga@slub-dresden.de"
+      "wcs_contactperson" "Dominik Stoltz"
+      "wcs_contactelectronicmailaddress" "dominik.stoltz@slub-dresden.de"
     END
   END
 


### PR DESCRIPTION
This PR contains a fix as well as a better support for maps with large scales.

### Description regarding calculation of max zoom level for TMS
```python3
    geo_tiff = gdal.Open(path_image)
    geo_transform = geo_tiff.GetGeoTransform()
    degrees_per_pixel = geo_transform[1]
    radius = 6378137
    equator = 2 * math.pi * radius
    meters_per_degree = equator / 360
    resolution = degrees_per_pixel * meters_per_degree
    pixels_per_tile = 256
    zoom_level = math.log((equator / pixels_per_tile) / resolution, 2)
    MAX_ZOOM_LEVEL = 20
    optimal_zoom_level = min(math.floor(zoom_level), MAX_ZOOM_LEVEL)
```

* Geo-Transform Data: The function extracts critical geo-transform data, including degrees per pixel, from the target image.
* Resolution Calculation: It calculates the image's resolution by factoring in Earth's dimensions and the commonly used tile size of 256 pixels.
* Logarithmic Precision: Through logarithmic calculations, it determines the ideal maximum zoom level, striking the perfect balance between image clarity and performance.
* Practical Constraint: To align with standard mapping systems, the function sets a maximum zoom level at 20.


### Changes
* The maximum `zoomLevel` for the TMS generation is now calculated from the georeference image instead of hard coded. In the past the hard coded variant showed massive processing issues for maps with a really large scale
* The metadata in the map services was updated
* Fixed a bug within the metadata update tasks, which lead to removing georeference images if the metadata was updated form them.